### PR TITLE
Do not run some tox envs by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,36},lint,docs,deploy
+envlist = lint,py{27,36}
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
When testing with a bare `tox` command, do not run some tests. The
deploy environment for instance is only interesting if we actually
want to deploy the code. The same goes for the docs environment.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>