### PR TITLE
Add commandline parsing

### DIFF
--- a/filechooser/parse_commandline.py
+++ b/filechooser/parse_commandline.py
@@ -1,0 +1,50 @@
+import argparse
+
+
+def parse_commandline():
+    """Parse the command line."""
+
+    parser = argparse.ArgumentParser(description="""This script
+randomly picks a chosen numer of files from a set of folders and
+copies those files to a single destination folder. The files to be
+considered can be filtered by suffix.""")
+
+    parser.add_argument(
+        "DIR",
+        help="The directory to consider (scanned recursively)",
+        nargs="+")
+
+    parser.add_argument(
+        "-N",
+        help="Choose N files randomly",
+        type=int,
+        default=10)
+
+    parser.add_argument(
+        "--destination",
+        metavar="DIR",
+        help="Copy files to DIR")
+
+    parser.add_argument(
+        "--delete-existing",
+        help="""Delete existing files in the destionation folder
+instead of moving those files to a new location.""",
+        action="store_true",
+        default=False)
+
+    parser.add_argument(
+        "--suffix",
+        help="""Only consider files with this SUFFIX. For instance, to
+only load jpeg files you would specify either 'jpg' or '.jpg'. By
+default, all files are be considered. The suffix is case
+insensitive.""",
+        action="append",
+        nargs="+")
+
+    parser.add_argument(
+        "--verbose",
+        help="Print a lot of stuff",
+        action="store_true",
+        default=False)
+
+    return parser.parse_args()

--- a/filechooser/parse_commandline.py
+++ b/filechooser/parse_commandline.py
@@ -47,4 +47,9 @@ insensitive.""",
         action="store_true",
         default=False)
 
-    return parser.parse_args()
+    options = parser.parse_args()
+
+    if options.N is not None and options.N < 1:
+        raise Exception("Argument -N can not be less than 1")
+
+    return options

--- a/tests/test_parse_commandline.py
+++ b/tests/test_parse_commandline.py
@@ -30,3 +30,15 @@ class TestParseCommandline(unittest.TestCase):
                                ["/scriptpath", "-N", "10", "/images"]):
             options = parse_commandline.parse_commandline()
         self.assertEqual(options.N, 10)
+
+    def test_illegal_N(self):
+        with mock.patch.object(sys, "argv",
+                               ["/scriptpath", "-N", "a", "/images"]):
+            with self.assertRaises(SystemExit):
+                parse_commandline.parse_commandline()
+
+    def test_negative_N(self):
+        with mock.patch.object(sys, "argv",
+                               ["/scriptpath", "-N", "-10", "/images"]):
+            with self.assertRaisesRegexp(Exception, "can not be less than"):
+                parse_commandline.parse_commandline()

--- a/tests/test_parse_commandline.py
+++ b/tests/test_parse_commandline.py
@@ -24,3 +24,9 @@ class TestParseCommandline(unittest.TestCase):
         self.assertTrue(isinstance(options.DIR, list))
         self.assertTrue(len(options.DIR) == 2)
         self.assertEqual(options.DIR, testdirs)
+
+    def test_N(self):
+        with mock.patch.object(sys, "argv",
+                               ["/scriptpath", "-N", "10", "/images"]):
+            options = parse_commandline.parse_commandline()
+        self.assertEqual(options.N, 10)

--- a/tests/test_parse_commandline.py
+++ b/tests/test_parse_commandline.py
@@ -1,0 +1,26 @@
+import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+import sys
+
+from filechooser import parse_commandline
+
+
+class TestParseCommandline(unittest.TestCase):
+
+    def test_empty_dirs(self):
+        with mock.patch.object(sys, "argv", ["/script"]):
+            with self.assertRaises(SystemExit):
+                parse_commandline.parse_commandline()
+
+    def test_dirs(self):
+        testdirs = ["/images-1", "/images-2"]
+        with mock.patch.object(sys, "argv", ["/scriptpath"] + testdirs):
+            options = parse_commandline.parse_commandline()
+        self.assertTrue(isinstance(options.DIR, list))
+        self.assertTrue(len(options.DIR) == 2)
+        self.assertEqual(options.DIR, testdirs)


### PR DESCRIPTION
This change adds the command line arguments from the legacy code. It
also adds a first unit test for the `DIR` argument.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>