### PR TITLE
Fetch all commits for package version

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
The package version is created based on git tags which requires a more
complete git commit history. Set `fetch-depth` conservatively to all.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>