### PR TITLE
Fix missing version if not using git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.version

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python
 
+import os.path
 import setuptools
 import subprocess
 
 
 def get_latest_tag():
+    version = "unknown"
+    try:
+        with open('.version') as fd:
+            version = fd.readline()
+        return version
+    except FileNotFoundError:
+        pass
+
     git = subprocess.Popen(['git', 'describe', '--tags'],
                            stdout=subprocess.PIPE,
                            universal_newlines=True)
@@ -14,14 +23,15 @@ def get_latest_tag():
         version = raw_version[0]
         if len(raw_version) > 1:
             version += ".dev" + raw_version[1]
-        return version
-    else:
-        return "unknown"
+    with open('.version', 'w') as fd:
+        fd.write('{}\n'.format(version))
+    return version
 
 
 setuptools.setup(
     name="filechooser",
     version=get_latest_tag(),
+    data_files=['.version'],
     license="BSD",
     url="https://github.com/nicolasbock/filechooser.git",
     project_urls={


### PR DESCRIPTION
If not using git the version cannot be generated. Use a git context to
generate the version and save it to a file.

This fixes the two stage process of `python -m build`.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>