### PR TITLE
Do not test on Go 1.16 anymore

### DIFF
--- a/.github/workflows/go-package.yaml
+++ b/.github/workflows/go-package.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-            go-version: ["1.16", "1.17", "1.18", "1.19", "1.20"]
+            go-version: ["1.17", "1.18", "1.19", "1.20"]
         fail-fast: false
 
     steps:


### PR DESCRIPTION
Go 1.16 fails with latest versions of dependencies (golang.org/x/sys).

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
